### PR TITLE
CocoaPods support. Old SDK support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,12 @@ on:
     types: [created]
 jobs:
   publish:
-    runs-on: macOS-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Publish Pod
         run: pod trunk push --allow-warnings
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+        run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - name: Publish Pod
         run: pod trunk push --allow-warnings
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+        run: sudo xcode-select -s /Applications/Xcode_14.0.app
       - name: Publish Pod
         run: pod trunk push --allow-warnings
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Publish CocoaPods package
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Publish Pod
+        run: pod trunk push --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+        run: sudo xcode-select -s /Applications/Xcode_14.3.app
       - name: Publish Pod
         run: pod trunk push --allow-warnings
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         xcode: ['14.2', '14.3']
-    runs-on: macOS-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        xcode: ['14.2', '14.3']
+        xcode: ['14.2', '14.3.1']
     runs-on: macos-13
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,23 @@ jobs:
         uses: actions/checkout@v3
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_14.2.app
-      - name: Build and Test SPM
-        run: swift test
-      - name: Build and Test CocoaPods
+      - name: Build and Test macOS
+        run: xcodebuild test -scheme 'Numberick' -destination "platform=macOS"
+      - name: Benchmarks macOS
+        run: xcodebuild test -scheme 'Numberick-Benchmarks' -destination "platform=macOS"
+      - name: Build and Test iOS Simulator
+        run: xcodebuild test -scheme 'Numberick' -destination "platform=iOS Simulator,name=iPhone 14"
+      - name: Benchmarks iOS Simulator
+        run: xcodebuild test -scheme 'Numberick-Benchmarks' -destination "platform=iOS Simulator,name=iPhone 14"
+      - name: Build and Test tvOS Simulator
+        run: xcodebuild test -scheme 'Numberick' -destination "platform=tvOS Simulator,name=Apple TV"
+      - name: Benchmarks tvOS Simulator
+        run: xcodebuild test -scheme 'Numberick-Benchmarks' -destination "platform=tvOS Simulator,name=Apple TV"
+      - name: Build and Test watchOS Simulator
+        run: xcodebuild test -scheme 'Numberick' -destination "platform=watchOS Simulator,name=Apple Watch Series 6 (40mm)"
+      - name: Benchmarks watchOS Simulator
+        run: xcodebuild test -scheme 'Numberick-Benchmarks' -destination "platform=watchOS Simulator,name=Apple Watch Series 6 (40mm)"
+      - name: CocoaPods Lint
         run: pod lib lint --allow-warnings --fail-fast
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Build & Tests
+on: [push, pull_request]
+jobs:
+  macos:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Build and Test SPM
+        run: swift test
+      - name: Build and Test CocoaPods
+        run: pod lib lint --allow-warnings --fail-fast
+  linux:
+    runs-on: ubuntu-latest
+    container:
+      image: swift:5.8.1
+      options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build and Test
+        run: swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+        run: sudo xcode-select -s /Applications/Xcode_14.0.app
       - name: Build and Test SPM
         run: swift test
       - name: Build and Test CocoaPods

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,15 @@ name: Build & Tests
 on: [push, pull_request]
 jobs:
   macos:
+    strategy:
+      matrix:
+        xcode: ['14.2', '14.3']
     runs-on: macOS-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Build and Test macOS
         run: xcodebuild test -scheme 'Numberick' -destination "platform=macOS"
       - name: Benchmarks macOS
@@ -27,9 +30,12 @@ jobs:
       - name: CocoaPods Lint
         run: pod lib lint --allow-warnings --fail-fast
   linux:
+    strategy:
+      matrix:
+        swift: ['5.7', '5.8']
     runs-on: ubuntu-latest
     container:
-      image: swift:5.8.1
+      image: swift:${{ matrix.swift }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and Test
         run: swift test
+      - name: Run Benchmarks
+        run: swift test -c release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+        run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - name: Build and Test SPM
         run: swift test
       - name: Build and Test CocoaPods

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name             = 'Numberick'
+  s.version          = '0.8.0'
+  s.summary          = 'A composable, large, fixed-width, two's complement, binary integer.'
+
+  s.description      = <<-DESC
+  A generic software model for working with fixed-width integers larger 
+  than one machine word. Its bit width is double the bit width of its High component.
+                       DESC
+
+  s.homepage         = 'https://github.com/oscbyspro/Numberick'
+
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
+  s.author           = { 'Oscar Byström Ericsson' => 'oscbyspro@protonmail.com' }
+  s.source           = { :git => 'https://github.com/oscbyspro/Numberick.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '13.0'
+  s.watchos.deployment_target = '6.0'
+  
+  s.swift_version = '5.8'
+  
+  s.source_files = 'Sources/NBKCoreKit/**/*.swift', 'Sources/NBKDoubleWidthKit/*.swift'
+  
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.platforms = {:ios => '13.0', :osx => '10.15', :tvos => '13.0'}
+    test_spec.source_files = 'Tests/NBKCoreKitTests/**/*.swift', 'Tests/NBKDoubleWidthKitTests/*.swift'
+  end
+end

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.author           = { 'Oscar Byström Ericsson' => 'oscbyspro@protonmail.com' }
   s.source           = { :git => 'https://github.com/oscbyspro/Numberick.git', :tag => "v#{s.version}" }
 
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '11.0'
-  s.watchos.deployment_target = '6.0'
+  s.ios.deployment_target = '14.0'
+  s.osx.deployment_target = '11.0'
+  s.tvos.deployment_target = '14.0'
+  s.watchos.deployment_target = '7.0'
   
   s.swift_version = '5.7'
   
   s.source_files = 'Sources/NBKCoreKit/**/*.swift', 'Sources/NBKDoubleWidthKit/*.swift'
   
   s.test_spec 'Tests' do |test_spec|
-    test_spec.platforms = {:ios => '11.0', :osx => '10.13', :tvos => '11.0'}
+    # test_spec.platforms = {:ios => '11.0', :osx => '10.13', :tvos => '11.0'}
     test_spec.source_files = 'Tests/NBKCoreKitTests/**/*.swift', 'Tests/NBKDoubleWidthKitTests/*.swift'
   end
 end

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   
   s.source_files = 'Sources/NBKCoreKit/**/*.swift', 'Sources/NBKDoubleWidthKit/*.swift'
   
-  s.test_spec 'Tests' do |test_spec|
-    # test_spec.platforms = {:ios => '11.0', :osx => '10.13', :tvos => '11.0'}
-    test_spec.source_files = 'Tests/NBKCoreKitTests/**/*.swift', 'Tests/NBKDoubleWidthKitTests/*.swift'
+  s.test_spec 'Tests' do |ts|
+    ts.platforms = {:ios => '14.0', :osx => '11.0', :tvos => '14.0'}
+    ts.source_files = 'Tests/NBKCoreKitTests/**/*.swift', 'Tests/NBKDoubleWidthKitTests/*.swift'
   end
 end

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.author           = { 'Oscar Byström Ericsson' => 'oscbyspro@protonmail.com' }
   s.source           = { :git => 'https://github.com/oscbyspro/Numberick.git', :tag => "v#{s.version}" }
 
-  s.ios.deployment_target = '13.0'
-  s.osx.deployment_target = '10.15'
-  s.tvos.deployment_target = '13.0'
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '11.0'
   s.watchos.deployment_target = '6.0'
   
-  s.swift_version = '5.8'
+  s.swift_version = '5.7'
   
   s.source_files = 'Sources/NBKCoreKit/**/*.swift', 'Sources/NBKDoubleWidthKit/*.swift'
   
   s.test_spec 'Tests' do |test_spec|
-    test_spec.platforms = {:ios => '13.0', :osx => '10.15', :tvos => '13.0'}
+    test_spec.platforms = {:ios => '11.0', :osx => '10.13', :tvos => '11.0'}
     test_spec.source_files = 'Tests/NBKCoreKitTests/**/*.swift', 'Tests/NBKDoubleWidthKitTests/*.swift'
   end
 end

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.author           = { 'Oscar Byström Ericsson' => 'oscbyspro@protonmail.com' }
-  s.source           = { :git => 'https://github.com/oscbyspro/Numberick.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/oscbyspro/Numberick.git', :tag => "v#{s.version}" }
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'

--- a/Numberick.podspec
+++ b/Numberick.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Numberick'
   s.version          = '0.8.0'
-  s.summary          = 'A composable, large, fixed-width, two's complement, binary integer.'
+  s.summary          = "A composable, large, fixed-width, two's complement, binary integer."
 
   s.description      = <<-DESC
   A generic software model for working with fixed-width integers larger 

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     platforms: [
         .iOS("11.0"),
         .macCatalyst("13.0"),
-        .macOS("10.13"),
+        .macOS("11.0"),
         .tvOS("11.0"),
         .watchOS("6.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7
 //=----------------------------------------------------------------------------=
 // This source file is part of the Numberick open source project.
 //
@@ -17,11 +17,11 @@ import PackageDescription
 let package = Package(
     name: "Numberick",
     platforms: [
-        .iOS("16.4"),
-        .macCatalyst("16.4"),
-        .macOS("13.3"),
-        .tvOS("16.4"),
-        .watchOS("9.4"),
+        .iOS("11.0"),
+        .macCatalyst("13.0"),
+        .macOS("10.13"),
+        .tvOS("11.0"),
+        .watchOS("6.0"),
     ],
     products: [
         //=--------------------------------------=

--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,11 @@ import PackageDescription
 let package = Package(
     name: "Numberick",
     platforms: [
-        .iOS("11.0"),
-        .macCatalyst("13.0"),
+        .iOS("14.0"),
+        .macCatalyst("14.0"),
         .macOS("11.0"),
-        .tvOS("11.0"),
-        .watchOS("6.0"),
+        .tvOS("14.0"),
+        .watchOS("7.0"),
     ],
     products: [
         //=--------------------------------------=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | Package | Swift | iOS  | iPadOS | Mac Catalyst | macOS | tvOS | watchOS |
 |:-------:|:-----:|:----:|:------:|:------------:|:-----:|:----:|:-------:|
-| 0.8.0   | 5.8   | 16.4 | 16.4   | 16.4         | 13.3  | 16.4 | 9.4     |
+| 0.8.0   | 5.7+  | 14+  | 14+    | 14+          | 11+   | 14+  | 7+      |
 
 ## NBKCoreKit ([Sources][COR/S], [Tests][COR/T], [Benchmarks][COR/B])
 

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Addition+Digit.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Addition+Digit.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Addition x Digit

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Addition.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Addition.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Addition

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Bits.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Bits.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Bits

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Comparisons.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Comparisons.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Comparisons

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Complements.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Complements.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Complements

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division+Digit.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division+Digit.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Division x Digit

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Division

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
@@ -86,11 +86,9 @@ extension NBKDoubleWidth {
         self.dividingFullWidthReportingOverflow(NBKDoubleWidth<Self>(descending: other))
     }
 
-#if swift(>=5.8)
     @_specialize(where Self == UInt128) @_specialize(where Self == Int128)
     @_specialize(where Self == UInt256) @_specialize(where Self == Int256)
     @_specialize(where Self == UInt512) @_specialize(where Self == Int512)
-#endif
     @inlinable public func dividingFullWidthReportingOverflow(_ other: NBKDoubleWidth<Self>) -> PVO<QR<Self, Self>> {
         let lhsIsLessThanZero: Bool = other.isLessThanZero
         let rhsIsLessThanZero: Bool = self .isLessThanZero

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Division.swift
@@ -83,10 +83,12 @@ extension NBKDoubleWidth {
     @inlinable public func dividingFullWidthReportingOverflow(_ other: HL<Self, Magnitude>) -> PVO<QR<Self, Self>> {
         self.dividingFullWidthReportingOverflow(NBKDoubleWidth<Self>(descending: other))
     }
-    
+
+#if swift(>=5.8)
     @_specialize(where Self == UInt128) @_specialize(where Self == Int128)
     @_specialize(where Self == UInt256) @_specialize(where Self == Int256)
     @_specialize(where Self == UInt512) @_specialize(where Self == Int512)
+#endif
     @inlinable public func dividingFullWidthReportingOverflow(_ other: NBKDoubleWidth<Self>) -> PVO<QR<Self, Self>> {
         let lhsIsLessThanZero: Bool = other.isLessThanZero
         let rhsIsLessThanZero: Bool = self .isLessThanZero

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Endianness.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Endianness.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Endianness

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
@@ -19,35 +19,32 @@ extension NBKDoubleWidth {
     }
 }
 
-#if swift(>=5.8)
-
-@available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-extension NBKDoubleWidth {
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Initializers
-    //=------------------------------------------------------------------------=
-    
-    @inlinable public init(integerLiteral source: StaticBigInt) {
-        guard let value = Self(exactlyIntegerLiteral: source) else {
-            preconditionFailure("\(Self.description) cannot represent \(source)")
-        }
-        
-        self = value
-    }
-    
-    @inlinable init?(exactlyIntegerLiteral source: StaticBigInt) {
-        guard Self.isSigned
-        ? source.bitWidth <= Self.bitWidth
-        : source.bitWidth <= Self.bitWidth + 1 && source.signum() >= 0
-        else { return nil }
-        
-        self = Self.uninitialized { value in
-            for index in value.indices {
-                value[unchecked: index] = source[index]
-            }
-        }
-    }
-}
-
-#endif
+// StaticBigInt available only from macOS 13.3.
+// Enable when drop old OS support
+//extension NBKDoubleWidth {
+//
+//    //=------------------------------------------------------------------------=
+//    // MARK: Initializers
+//    //=------------------------------------------------------------------------=
+//
+//    @inlinable public init(integerLiteral source: StaticBigInt) {
+//        guard let value = Self(exactlyIntegerLiteral: source) else {
+//            preconditionFailure("\(Self.description) cannot represent \(source)")
+//        }
+//
+//        self = value
+//    }
+//
+//    @inlinable init?(exactlyIntegerLiteral source: StaticBigInt) {
+//        guard Self.isSigned
+//        ? source.bitWidth <= Self.bitWidth
+//        : source.bitWidth <= Self.bitWidth + 1 && source.signum() >= 0
+//        else { return nil }
+//
+//        self = Self.uninitialized { value in
+//            for index in value.indices {
+//                value[unchecked: index] = source[index]
+//            }
+//        }
+//    }
+//}

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
@@ -11,11 +11,18 @@
 // MARK: * NBK x Double Width x IntegerLiteral
 //*============================================================================*
 
+extension NBKDoubleWidth {
+    public typealias IntegerLiteralType = Int64
+    
+    @inlinable public init(integerLiteral source: Int64) {
+        self.init(source)
+    }
+}
+
 #if swift(>=5.8)
 
 @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
 extension NBKDoubleWidth {
-    public typealias IntegerLiteralType = StaticBigInt
     
     //=------------------------------------------------------------------------=
     // MARK: Initializers
@@ -44,9 +51,3 @@ extension NBKDoubleWidth {
 }
 
 #endif
-
-extension NBKDoubleWidth {
-    @inlinable public init(integerLiteral source: Int64) {
-        self.init(source)
-    }
-}

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+IntegerLiteral.swift
@@ -1,0 +1,52 @@
+//=----------------------------------------------------------------------------=
+// This source file is part of the Numberick open source project.
+//
+// Copyright (c) 2023 Oscar Byström Ericsson
+// Licensed under Apache License, Version 2.0
+//
+// See http://www.apache.org/licenses/LICENSE-2.0 for license information.
+//=----------------------------------------------------------------------------=
+
+//*============================================================================*
+// MARK: * NBK x Double Width x IntegerLiteral
+//*============================================================================*
+
+#if swift(>=5.8)
+
+@available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
+extension NBKDoubleWidth {
+    public typealias IntegerLiteralType = StaticBigInt
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Initializers
+    //=------------------------------------------------------------------------=
+    
+    @inlinable public init(integerLiteral source: StaticBigInt) {
+        guard let value = Self(exactlyIntegerLiteral: source) else {
+            preconditionFailure("\(Self.description) cannot represent \(source)")
+        }
+        
+        self = value
+    }
+    
+    @inlinable init?(exactlyIntegerLiteral source: StaticBigInt) {
+        guard Self.isSigned
+        ? source.bitWidth <= Self.bitWidth
+        : source.bitWidth <= Self.bitWidth + 1 && source.signum() >= 0
+        else { return nil }
+        
+        self = Self.uninitialized { value in
+            for index in value.indices {
+                value[unchecked: index] = source[index]
+            }
+        }
+    }
+}
+
+#endif
+
+extension NBKDoubleWidth {
+    @inlinable public init(integerLiteral source: Int64) {
+        self.init(source)
+    }
+}

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Logic.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Logic.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Logic

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Multiplication+Digit.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Multiplication+Digit.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Multiplication x Digit

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Multiplication.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Multiplication.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Multiplication

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
@@ -44,11 +44,12 @@ extension NBKDoubleWidth {
         self.init(low: Low(_truncatingBits: source))
     }
     
-#if swift(>=5.8)
     //=------------------------------------------------------------------------=
     // MARK: Initializers
     //=------------------------------------------------------------------------=
-    
+
+#if swift(>=5.8)
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     @inlinable public init(integerLiteral source: StaticBigInt) {
         guard let value = Self(exactlyIntegerLiteral: source) else {
             preconditionFailure("\(Self.description) cannot represent \(source)")
@@ -57,6 +58,7 @@ extension NBKDoubleWidth {
         self = value
     }
     
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     @inlinable init?(exactlyIntegerLiteral source: StaticBigInt) {
         guard Self.isSigned
         ? source.bitWidth <= Self.bitWidth
@@ -69,11 +71,11 @@ extension NBKDoubleWidth {
             }
         }
     }
-#else
-    @inlinable public init(integerLiteral source: Int) {
+#endif
+
+    @inlinable public init(integerLiteral source: Int64) {
         self.init(source)
     }
-#endif
     
     //=------------------------------------------------------------------------=
     // MARK: Initializers

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
@@ -47,39 +47,6 @@ extension NBKDoubleWidth {
     //=------------------------------------------------------------------------=
     // MARK: Initializers
     //=------------------------------------------------------------------------=
-
-#if swift(>=5.8)
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-    @inlinable public init(integerLiteral source: StaticBigInt) {
-        guard let value = Self(exactlyIntegerLiteral: source) else {
-            preconditionFailure("\(Self.description) cannot represent \(source)")
-        }
-        
-        self = value
-    }
-    
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-    @inlinable init?(exactlyIntegerLiteral source: StaticBigInt) {
-        guard Self.isSigned
-        ? source.bitWidth <= Self.bitWidth
-        : source.bitWidth <= Self.bitWidth + 1 && source.signum() >= 0
-        else { return nil }
-        
-        self = Self.uninitialized { value in
-            for index in value.indices {
-                value[unchecked: index] = source[index]
-            }
-        }
-    }
-#endif
-
-    @inlinable public init(integerLiteral source: Int64) {
-        self.init(source)
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Initializers
-    //=------------------------------------------------------------------------=
     
     @inlinable public init(_ source: some BinaryInteger) {
         guard let result = Self(exactly: source) else {

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
@@ -42,6 +42,7 @@ extension NBKDoubleWidth {
         self.init(low: Low(_truncatingBits: source))
     }
     
+#if swift(>=5.8)
     //=------------------------------------------------------------------------=
     // MARK: Initializers
     //=------------------------------------------------------------------------=
@@ -66,6 +67,11 @@ extension NBKDoubleWidth {
             }
         }
     }
+#else
+    @inlinable public init(integerLiteral source: Int) {
+        self.init(source)
+    }
+#endif
     
     //=------------------------------------------------------------------------=
     // MARK: Initializers

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Numbers.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Numbers

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Rotations.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Rotations.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Rotations x Left

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Shifts.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Shifts.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Shifts x Left

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Strides.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Strides.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Strides

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Subtraction+Digit.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Subtraction+Digit.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Subtraction x Digit

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Subtraction.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Subtraction.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Subtraction

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Text.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Text.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Text

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Words+Pointers.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Words+Pointers.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Words x Pointers

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Words.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth+Words.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width x Words

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+#if !COCOAPODS
 import NBKCoreKit
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Double Width

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
@@ -102,6 +102,12 @@ High: NBKFixedWidthInteger,  High.Digit: NBKCoreInteger<UInt> {
     /// The bit pattern of this type.
     public typealias BitPattern = NBKDoubleWidth<High.Magnitude>
     
+#if swift(>=5.8)
+    /// Typealias for ExpressibleByIntegerLiteral
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
+    public typealias IntegerLiteralType = StaticBigInt
+#endif
+    
     //=------------------------------------------------------------------------=
     // MARK: Accessors
     //=------------------------------------------------------------------------=

--- a/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
+++ b/Sources/NBKDoubleWidthKit/NBKDoubleWidth.swift
@@ -102,12 +102,6 @@ High: NBKFixedWidthInteger,  High.Digit: NBKCoreInteger<UInt> {
     /// The bit pattern of this type.
     public typealias BitPattern = NBKDoubleWidth<High.Magnitude>
     
-#if swift(>=5.8)
-    /// Typealias for ExpressibleByIntegerLiteral
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-    public typealias IntegerLiteralType = StaticBigInt
-#endif
-    
     //=------------------------------------------------------------------------=
     // MARK: Accessors
     //=------------------------------------------------------------------------=

--- a/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Bits.swift
+++ b/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Bits.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Bits x Int

--- a/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Comparisons.swift
+++ b/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Comparisons.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Comparisons x Int

--- a/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Division.swift
+++ b/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Division.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Division x Int

--- a/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Rotations.swift
+++ b/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Rotations.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Rotations x Int

--- a/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Shifts.swift
+++ b/Tests/NBKCoreKitBenchmarks/NBKCoreInteger+Shifts.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Shifts x Int

--- a/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs+Bits.swift
+++ b/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs+Bits.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Limbs x Bits

--- a/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs+Comparisons.swift
+++ b/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs+Comparisons.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs.swift
+++ b/Tests/NBKCoreKitBenchmarks/Private/NBK+Limbs.swift
@@ -9,8 +9,12 @@
 
 #if !DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Addition.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Addition.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Addition

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Bits.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Bits.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Bits

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Comparisons.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Comparisons.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Comparisons

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Complements.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Complements.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Complements

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Division.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Division.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Division

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Multiplication.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Multiplication.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Multiplication

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Numbers.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Numbers.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Numbers

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Rotations.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Rotations.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Rotations

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Shifts.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Shifts.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Shifts

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Subtraction.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Subtraction.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Subtraction

--- a/Tests/NBKCoreKitTests/NBKCoreInteger+Text.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger+Text.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer x Text

--- a/Tests/NBKCoreKitTests/NBKCoreInteger.swift
+++ b/Tests/NBKCoreKitTests/NBKCoreInteger.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Core Integer

--- a/Tests/NBKCoreKitTests/Private/NBK+BitCast.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+BitCast.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Bit Cast

--- a/Tests/NBKCoreKitTests/Private/NBK+Collection.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Collection.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Collection

--- a/Tests/NBKCoreKitTests/Private/NBK+Division.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Division.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Addition.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Addition.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Bits.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Bits.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Limbs x Bits

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Comparisons.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Comparisons.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Division.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Division.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Multiplication.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Multiplication.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs+Subtraction.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs+Subtraction.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Limbs.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Limbs.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 private typealias W = [UInt]
 private typealias X = [UInt64]

--- a/Tests/NBKCoreKitTests/Private/NBK+Text+Components.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Text+Components.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Text x Components

--- a/Tests/NBKCoreKitTests/Private/NBK+Text+RadixAlphabet.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Text+RadixAlphabet.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Text x Radix Alphabet

--- a/Tests/NBKCoreKitTests/Private/NBK+Text+RadixUIntRoot.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Text+RadixUIntRoot.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Text x Radix UInt Root

--- a/Tests/NBKCoreKitTests/Private/NBK+Text.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Text.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Text

--- a/Tests/NBKCoreKitTests/Private/NBK+Tuples.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Tuples.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Tuples

--- a/Tests/NBKCoreKitTests/Private/NBK+Words.swift
+++ b/Tests/NBKCoreKitTests/Private/NBK+Words.swift
@@ -9,8 +9,12 @@
 
 #if DEBUG
 
-import NBKCoreKit
 import XCTest
+#if !COCOAPODS
+import NBKCoreKit
+#else
+import Numberick
+#endif
 
 //*============================================================================*
 // MARK: * NBK x Words

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Addition.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Addition.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Bits.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Bits.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Comparisons.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Comparisons.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Complements.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Complements.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Division.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Division.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Endianness.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Endianness.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Logic.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Logic.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Multiplication.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Multiplication.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Numbers.swift
@@ -369,28 +369,29 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsInt256: XCTestCase {
     // MARK: Tests x Float
     //=------------------------------------------------------------------------=
     
-#if swift(>=5.8)
     // TODO: brrr
-    func testToFloat16() {
-        var abc = NBK.blackHoleIdentity(T.max)
-        
-        for _ in 0 ..< 1_000 {
-            NBK.blackHole(Float16(abc))
-            NBK.blackHole(Float16(exactly: abc))
-            NBK.blackHoleInoutIdentity(&abc)
-        }
-    }
-    
-    func testFromFloat16() {
-        var abc = NBK.blackHoleIdentity(Float16(123))
-        
-        for _ in 0 ..< 250_000 {
-            NBK.blackHole(T(abc))
-            NBK.blackHole(T(exactly: abc))
-            NBK.blackHoleInoutIdentity(&abc)
-        }
-    }
-#endif
+    // Float16 doesn't have BinaryInteger initializers
+//#if swift(>=5.8)
+//    func testToFloat16() {
+//        var abc = NBK.blackHoleIdentity(T.max)
+//
+//        for _ in 0 ..< 1_000 {
+//            NBK.blackHole(Float16(abc))
+//            NBK.blackHole(Float16(exactly: abc))
+//            NBK.blackHoleInoutIdentity(&abc)
+//        }
+//    }
+//
+//    func testFromFloat16() {
+//        var abc = NBK.blackHoleIdentity(Float16(123))
+//
+//        for _ in 0 ..< 250_000 {
+//            NBK.blackHole(T(abc))
+//            NBK.blackHole(T(exactly: abc))
+//            NBK.blackHoleInoutIdentity(&abc)
+//        }
+//    }
+//#endif
     
     // TODO: brrr
     func testToFloat32() {
@@ -801,28 +802,29 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsUInt256: XCTestCase {
     // MARK: Tests x Float
     //=------------------------------------------------------------------------=
 
-#if swift(>=5.8)
     // TODO: brrr
-    func testToFloat16() {
-        var abc = NBK.blackHoleIdentity(T.max)
-        
-        for _ in 0 ..< 1_000 {
-            NBK.blackHole(Float16(abc))
-            NBK.blackHole(Float16(exactly: abc))
-            NBK.blackHoleInoutIdentity(&abc)
-        }
-    }
-    
-    func testFromFloat16() {
-        var abc = NBK.blackHoleIdentity(Float16(123))
-        
-        for _ in 0 ..< 250_000 {
-            NBK.blackHole(T(abc))
-            NBK.blackHole(T(exactly: abc))
-            NBK.blackHoleInoutIdentity(&abc)
-        }
-    }
-#endif
+    // Float16 doesn't have BinaryInteger initializers
+//#if swift(>=5.8)
+//    func testToFloat16() {
+//        var abc = NBK.blackHoleIdentity(T.max)
+//
+//        for _ in 0 ..< 1_000 {
+//            NBK.blackHole(Float16(abc))
+//            NBK.blackHole(Float16(exactly: abc))
+//            NBK.blackHoleInoutIdentity(&abc)
+//        }
+//    }
+//
+//    func testFromFloat16() {
+//        var abc = NBK.blackHoleIdentity(Float16(123))
+//
+//        for _ in 0 ..< 250_000 {
+//            NBK.blackHole(T(abc))
+//            NBK.blackHole(T(exactly: abc))
+//            NBK.blackHoleInoutIdentity(&abc)
+//        }
+//    }
+//#endif
     
     // TODO: brrr
     func testToFloat32() {

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Numbers.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32
@@ -365,6 +369,7 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsInt256: XCTestCase {
     // MARK: Tests x Float
     //=------------------------------------------------------------------------=
     
+#if swift(>=5.8)
     // TODO: brrr
     func testToFloat16() {
         var abc = NBK.blackHoleIdentity(T.max)
@@ -385,6 +390,7 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsInt256: XCTestCase {
             NBK.blackHoleInoutIdentity(&abc)
         }
     }
+#endif
     
     // TODO: brrr
     func testToFloat32() {
@@ -794,7 +800,8 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsUInt256: XCTestCase {
     //=------------------------------------------------------------------------=
     // MARK: Tests x Float
     //=------------------------------------------------------------------------=
-    
+
+#if swift(>=5.8)
     // TODO: brrr
     func testToFloat16() {
         var abc = NBK.blackHoleIdentity(T.max)
@@ -815,6 +822,7 @@ final class NBKDoubleWidthBenchmarksOnNumbersAsUInt256: XCTestCase {
             NBK.blackHoleInoutIdentity(&abc)
         }
     }
+#endif
     
     // TODO: brrr
     func testToFloat32() {

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Random.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Random.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Rotations.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Rotations.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Shifts.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Shifts.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Strides.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Strides.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Subtraction.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Subtraction.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Text.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth+Text.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth.swift
+++ b/Tests/NBKDoubleWidthKitBenchmarks/NBKDoubleWidth.swift
@@ -9,9 +9,13 @@
 
 #if !DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Addition.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Addition.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Bits.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Bits.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Comparisons.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Comparisons.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Complements.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Complements.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Division.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Division.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Endianness.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Endianness.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Logic.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Logic.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Multiplication.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Multiplication.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 @testable import NBKDoubleWidthKit
-import XCTest
+#else
+@testable import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
@@ -157,13 +157,18 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
         NBKAssertNumbers(from: T(x64: X(~0, ~0, ~0, ~0)), exactly: nil, clamping:  0, truncating: UInt64.max)
     }
 
-#if swift(>=5.8)
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     func testFromUInt64() {
         NBKAssertNumbers(from: UInt64.min, default: T())
-        NBKAssertNumbers(from: UInt64.max, default: T(18446744073709551615))
+        NBKAssertNumbers(from: UInt64.min, default: T(UInt64.min))
+        NBKAssertNumbers(from: UInt64.max, default: T(UInt64.max))
     }
-#endif
+    
+    // StaticBigInt available only from macOS 13.3.
+    // Enable when drop old OS support
+    //func testFromUInt64Literal() {
+    //    NBKAssertNumbers(from: UInt64.min, default: T())
+    //    NBKAssertNumbers(from: UInt64.max, default: T(18446744073709551615))
+    //}
     
     //=------------------------------------------------------------------------=
     // MARK: Tests x Signitude
@@ -336,24 +341,24 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
     // MARK: Tests x Literal
     //=------------------------------------------------------------------------=
 
-#if swift(>=5.8)
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-    func testFromLiteral() {
-        XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
-        XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0,  0,  0)),  0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0, ~0,  0)),  0x0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0, ~0, ~0)), -0x0000000000000000000000000000000000000000000000000000000000000001)
-        XCTAssertEqual(T(x64: X( 0, ~0, ~0, ~0)), -0x0000000000000000000000000000000000000000000000010000000000000000)
-        XCTAssertEqual(T(x64: X( 0,  0, ~0, ~0)), -0x0000000000000000000000000000000100000000000000000000000000000000)
-        XCTAssertEqual(T(x64: X( 0,  0,  0, ~0)), -0x0000000000000001000000000000000000000000000000000000000000000000)
-                
-        XCTAssertEqual(T(exactlyIntegerLiteral:    0x8000000000000000000000000000000000000000000000000000000000000000),   nil)
-        XCTAssertEqual(T(exactlyIntegerLiteral:    0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), T.max)
-        XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000000), T.min)
-        XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000001),   nil)
-    }
-#endif
+    // StaticBigInt available only from macOS 13.3.
+    // Enable when drop old OS support
+    
+//    func testFromLiteral() {
+//        XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
+//        XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0,  0,  0)),  0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0, ~0,  0)),  0x0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0, ~0, ~0)), -0x0000000000000000000000000000000000000000000000000000000000000001)
+//        XCTAssertEqual(T(x64: X( 0, ~0, ~0, ~0)), -0x0000000000000000000000000000000000000000000000010000000000000000)
+//        XCTAssertEqual(T(x64: X( 0,  0, ~0, ~0)), -0x0000000000000000000000000000000100000000000000000000000000000000)
+//        XCTAssertEqual(T(x64: X( 0,  0,  0, ~0)), -0x0000000000000001000000000000000000000000000000000000000000000000)
+//
+//        XCTAssertEqual(T(exactlyIntegerLiteral:    0x8000000000000000000000000000000000000000000000000000000000000000),   nil)
+//        XCTAssertEqual(T(exactlyIntegerLiteral:    0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), T.max)
+//        XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000000), T.min)
+//        XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000001),   nil)
+//    }
 }
 
 //*============================================================================*
@@ -653,24 +658,25 @@ final class NBKDoubleWidthTestsOnNumbersAsUInt256: XCTestCase {
     //=------------------------------------------------------------------------=
     // MARK: Tests x Literal
     //=------------------------------------------------------------------------=
-#if swift(>=5.8)
-    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
-    func testFromLiteral() {
-        XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
-        XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0,  0,  0)),  0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0, ~0,  0)),  0x0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff)
-        XCTAssertEqual(T(x64: X(~0, ~0, ~0, ~0)),  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-        XCTAssertEqual(T(x64: X( 0, ~0, ~0, ~0)),  0xffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000)
-        XCTAssertEqual(T(x64: X( 0,  0, ~0, ~0)),  0xffffffffffffffffffffffffffffffff00000000000000000000000000000000)
-        XCTAssertEqual(T(x64: X( 0,  0,  0, ~0)),  0xffffffffffffffff000000000000000000000000000000000000000000000000)
-        
-        XCTAssertEqual(T(exactlyIntegerLiteral:  0x010000000000000000000000000000000000000000000000000000000000000000),   nil)
-        XCTAssertEqual(T(exactlyIntegerLiteral:  0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), T.max)
-        XCTAssertEqual(T(exactlyIntegerLiteral:  0x000000000000000000000000000000000000000000000000000000000000000000), T.min)
-        XCTAssertEqual(T(exactlyIntegerLiteral: -0x000000000000000000000000000000000000000000000000000000000000000001),   nil)
-    }
-#endif
+
+    // StaticBigInt available only from macOS 13.3.
+    // Enable when drop old OS support
+    
+//    func testFromLiteral() {
+//        XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
+//        XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0,  0,  0)),  0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0, ~0,  0)),  0x0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff)
+//        XCTAssertEqual(T(x64: X(~0, ~0, ~0, ~0)),  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+//        XCTAssertEqual(T(x64: X( 0, ~0, ~0, ~0)),  0xffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000)
+//        XCTAssertEqual(T(x64: X( 0,  0, ~0, ~0)),  0xffffffffffffffffffffffffffffffff00000000000000000000000000000000)
+//        XCTAssertEqual(T(x64: X( 0,  0,  0, ~0)),  0xffffffffffffffff000000000000000000000000000000000000000000000000)
+//
+//        XCTAssertEqual(T(exactlyIntegerLiteral:  0x010000000000000000000000000000000000000000000000000000000000000000),   nil)
+//        XCTAssertEqual(T(exactlyIntegerLiteral:  0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), T.max)
+//        XCTAssertEqual(T(exactlyIntegerLiteral:  0x000000000000000000000000000000000000000000000000000000000000000000), T.min)
+//        XCTAssertEqual(T(exactlyIntegerLiteral: -0x000000000000000000000000000000000000000000000000000000000000000001),   nil)
+//    }
 }
 
 //*============================================================================*

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
@@ -152,11 +152,13 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
         NBKAssertNumbers(from: T(x64: X( 1,  1,  1,  1)), exactly: nil, clamping: ~0, truncating: UInt64( 1))
         NBKAssertNumbers(from: T(x64: X(~0, ~0, ~0, ~0)), exactly: nil, clamping:  0, truncating: UInt64.max)
     }
-    
+
+#if swift(>=5.8)
     func testFromUInt64() {
         NBKAssertNumbers(from: UInt64.min, default: T())
         NBKAssertNumbers(from: UInt64.max, default: T(18446744073709551615))
     }
+#endif
     
     //=------------------------------------------------------------------------=
     // MARK: Tests x Signitude
@@ -328,7 +330,8 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
     //=------------------------------------------------------------------------=
     // MARK: Tests x Literal
     //=------------------------------------------------------------------------=
-    
+
+#if swift(>=5.8)
     func testFromLiteral() {
         XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
         XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
@@ -344,6 +347,7 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
         XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000000), T.min)
         XCTAssertEqual(T(exactlyIntegerLiteral:   -0x8000000000000000000000000000000000000000000000000000000000000001),   nil)
     }
+#endif
 }
 
 //*============================================================================*
@@ -643,7 +647,7 @@ final class NBKDoubleWidthTestsOnNumbersAsUInt256: XCTestCase {
     //=------------------------------------------------------------------------=
     // MARK: Tests x Literal
     //=------------------------------------------------------------------------=
-    
+#if swift(>=5.8)
     func testFromLiteral() {
         XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
         XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
@@ -659,6 +663,7 @@ final class NBKDoubleWidthTestsOnNumbersAsUInt256: XCTestCase {
         XCTAssertEqual(T(exactlyIntegerLiteral:  0x000000000000000000000000000000000000000000000000000000000000000000), T.min)
         XCTAssertEqual(T(exactlyIntegerLiteral: -0x000000000000000000000000000000000000000000000000000000000000000001),   nil)
     }
+#endif
 }
 
 //*============================================================================*

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Numbers.swift
@@ -158,6 +158,7 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
     }
 
 #if swift(>=5.8)
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     func testFromUInt64() {
         NBKAssertNumbers(from: UInt64.min, default: T())
         NBKAssertNumbers(from: UInt64.max, default: T(18446744073709551615))
@@ -336,6 +337,7 @@ final class NBKDoubleWidthTestsOnNumbersAsInt256: XCTestCase {
     //=------------------------------------------------------------------------=
 
 #if swift(>=5.8)
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     func testFromLiteral() {
         XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
         XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)
@@ -652,6 +654,7 @@ final class NBKDoubleWidthTestsOnNumbersAsUInt256: XCTestCase {
     // MARK: Tests x Literal
     //=------------------------------------------------------------------------=
 #if swift(>=5.8)
+    @available (iOS 16.4, tvOS 16.4, macOS 13.3, watchOS 9.4, macCatalyst 16.4, *)
     func testFromLiteral() {
         XCTAssertEqual(T(x64: X( 0,  0,  0,  0)),  0x0000000000000000000000000000000000000000000000000000000000000000)
         XCTAssertEqual(T(x64: X(~0,  0,  0,  0)),  0x000000000000000000000000000000000000000000000000ffffffffffffffff)

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Rotations.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Rotations.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Shifts.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Shifts.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Strides.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Strides.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = [UInt64]
 private typealias Y = [UInt64]

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Subtraction.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Subtraction.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Text.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Text.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Words.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth+Words.swift
@@ -9,9 +9,13 @@
 
 #if DEBUG
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32

--- a/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth.swift
+++ b/Tests/NBKDoubleWidthKitTests/NBKDoubleWidth.swift
@@ -7,9 +7,13 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+import XCTest
+#if !COCOAPODS
 import NBKCoreKit
 import NBKDoubleWidthKit
-import XCTest
+#else
+import Numberick
+#endif
 
 private typealias X = NBK.U256X64
 private typealias Y = NBK.U256X32


### PR DESCRIPTION
1. Added CocoaPods Podfile
2. Added GitHub Actions workflows for testing and deploying.
3. Switched it to the older Swift 5.7 and SDKs. I like the StaticBigInt constructor too, but it's supported only in the latest SDK versions :( More practical is `String` constructors for now.
4. Tested on Linux (and it works!)